### PR TITLE
表記が英語のままだとわかりにくかったので修正

### DIFF
--- a/translation-ja/responses.md
+++ b/translation-ja/responses.md
@@ -37,7 +37,7 @@
 
 #### レスポンスオブジェクト
 
-通常、皆さんは単純な文字列や配列をルートアクションから返すだけじゃありませんよね。代わりに、`Illuminate\Http\Response`インスタンスか[views](/docs/{{version}}/views)を返したいですよね。
+通常、皆さんは単純な文字列や配列をルートアクションから返すだけじゃありませんよね。代わりに、`Illuminate\Http\Response`インスタンスか[ビュー](/docs/{{version}}/views)を返したいですよね。
 
 完全な`Response`インスタンスを返せば、レスポンスのHTTPステータスコードやヘッダをカスタマイズできます。`Response`インスタンスは、`Symfony\Component\HttpFoundation\Response`クラスを継承しており、HTTPレスポンスを構築するためにさまざまなメソッドを提供しています。
 


### PR DESCRIPTION
`HTTPレスポンス` の章の `レスポンスオブジェクト` の中で `views` という表記で英語のままだとわかりにくかった + 他の表記でも `ビュー` と書かれていたので合わせました

https://readouble.com/laravel/7.x/ja/responses.html

ご確認よろしくおねがいします:bow: